### PR TITLE
Modifies what are allowable AWS credentials

### DIFF
--- a/cmd/service-wrapper/main.go
+++ b/cmd/service-wrapper/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	fmt.Printf("Starting service-wrapper")
+	fmt.Println("Starting service-wrapper")
 	httpc := &http.Client{}
 
 	aws := vaultaws.New(httpc)

--- a/processor/vault-aws/process.go
+++ b/processor/vault-aws/process.go
@@ -39,7 +39,10 @@ type config struct {
 	Role     string `envconfig:"VAULT_ROLE"`
 	Config   string `envconfig:"VAULT_SERVICE_CONFIG"`
 	Filename string `envconfig:"VAULT_SERVICE_FILE"`
-	AWSPath  string `envconfig:"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"`
+	// AWS Credentials
+	AWSPath   string `envconfig:"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"`
+	AWSAccess string `envconfig:"AWS_ACCESS_KEY_ID"`
+	AWSSecret string `envconfig:"AWS_SECRET_ACCESS_KEY"`
 }
 
 type Doer interface {
@@ -73,7 +76,8 @@ func (a *awsAuth) Init(c interface{}) (bool, error) {
 		return false, errors.New("bad config")
 	}
 
-	if cfg.Vault == "" || cfg.AWSPath == "" {
+	validAWSCredentials := cfg.AWSPath != "" || (cfg.AWSAccess != "" && cfg.AWSSecret != "")
+	if cfg.Vault == "" || !validAWSCredentials {
 		return false, nil
 	}
 

--- a/processor/vault-aws/process_test.go
+++ b/processor/vault-aws/process_test.go
@@ -11,6 +11,8 @@ import (
 
 const (
 	testAWSPath       = "/testing/path"
+	testAWSAccess     = "access"
+	testAWSSecret     = "secret"
 	testVaultEndpoint = "http://vault.local:8200"
 	testRole          = "aRole"
 	testClientToken   = "aToken"
@@ -51,10 +53,18 @@ func TestInitConfig(t *testing.T) {
 
 	tests := []testSet{
 		testSet{"no vault", false, false, func(c *config) { c.AWSPath = testAWSPath }},
-		testSet{"no AWSPath", false, false, func(c *config) { c.Vault = testVaultEndpoint }},
+		testSet{"no AWS creds", false, false, func(c *config) { c.Vault = testVaultEndpoint }},
+		testSet{"bad AWS creds (no secret)", false, false, func(c *config) { c.Vault = testVaultEndpoint; c.AWSAccess = testAWSAccess }},
+		testSet{"bad AWS creds (no access)", false, false, func(c *config) { c.Vault = testVaultEndpoint; c.AWSSecret = testAWSSecret }},
 		testSet{"vault invalid", false, true, func(c *config) { c.Vault = "broken:/bad url"; c.AWSPath = testAWSPath; c.Role = testRole }},
 		testSet{"missing role", false, true, func(c *config) { c.Vault = testVaultEndpoint; c.AWSPath = testAWSPath }},
-		testSet{"ok", true, false, func(c *config) { c.Vault = testVaultEndpoint; c.AWSPath = testAWSPath; c.Role = testRole }},
+		testSet{"ok AWS Path", true, false, func(c *config) { c.Vault = testVaultEndpoint; c.AWSPath = testAWSPath; c.Role = testRole }},
+		testSet{"ok AWS Token", true, false, func(c *config) {
+			c.Vault = testVaultEndpoint
+			c.AWSAccess = testAWSAccess
+			c.AWSSecret = testAWSSecret
+			c.Role = testRole
+		}},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Extends the set of allowed AWS credentials that will trigger the `vault-aws` processor.